### PR TITLE
perf: optimize scrolling for CSV files with large JSON fields

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@
 # Generated test data (large files)
 *.csv
 
+.cursor/

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,87 @@
+# QuickCSV Architecture & Core Logic
+
+This document explains the internal workings of QuickCSV. It is designed for developers who want to understand the high-performance techniques and Rust patterns used in this project.
+
+---
+
+## 1. High-Level Design
+
+QuickCSV uses an **Immediate Mode GUI** (`egui`) and a **Multi-threaded Architecture**. 
+
+- **UI Thread**: Handles rendering at 60 FPS. It must never perform blocking I/O or heavy computation.
+- **Worker Threads**: Handle file indexing, searching, and sorting in the background to keep the UI responsive.
+
+---
+
+## 2. Zero-Copy Memory Mapping (`MappedCsv`)
+
+Instead of loading the entire CSV into RAM, QuickCSV uses **Memory Mapping** via the `memmap2` crate.
+
+- **How it works**: The operating system maps the file on disk to a virtual memory address space.
+- **Benefit**: We can handle 2GB+ files while only using a few megabytes of RAM. The OS automatically manages loading "pages" of the file into physical memory only when we access specific byte ranges.
+
+```rust
+struct MappedCsv {
+    mmap: Mmap,                // The memory-mapped file data
+    row_offsets: Arc<RwLock<Vec<usize>>>, // Byte position of every row
+    // ...
+}
+```
+
+---
+
+## 3. Progressive Loading & Indexing
+
+QuickCSV doesn't make you wait for the whole file to be scanned.
+
+1. **Header Phase**: The app immediately finds the first row boundary to extract column names.
+2. **Ready State**: The app switches to `Ready` state and shows the first few rows instantly.
+3. **Background Indexing**: A thread scans the rest of the file for row boundaries (`\n` or `\r\n`).
+4. **Dynamic Update**: As the `row_offsets` list grows, the UI's scrollbar and row count update automatically.
+
+---
+
+## 4. RFC 4180 Compliant Parsing
+
+Standard CSV parsing is tricky because fields can contain newlines if they are quoted.
+
+- **`find_row_boundary`**: This function uses a small "State Machine" to track whether it is currently inside a quoted field. If it sees a newline (`\n`) while `in_quotes` is true, it treats it as regular text rather than a row ending.
+- **Field Parsing**: We use the `csv` crate for field extraction, but we use our own `find_row_boundary` logic for row-level indexing to maintain performance.
+
+---
+
+## 5. Virtualized Rendering
+
+Even with 10 million rows, the UI only ever "sees" the ~30 rows currently visible on your screen.
+
+- **The Table**: `egui_extras::TableBuilder` calculates which row indices are visible based on the scroll position.
+- **The Cache**: Parsing bytes into Strings is fast, but doing it every frame for every visible cell can be CPU-intensive. `FastCsvApp` maintains a `row_cache` (HashMap) of the most recently parsed rows to ensure smooth 60 FPS scrolling.
+
+---
+
+## 6. Search & Sort Logic
+
+### Search
+- **Background Scanning**: Search runs in a separate thread to avoid UI lag.
+- **Navigation vs. Highlighting**: We only store the first 10,000 match locations for navigation (Prev/Next). Highlighting is done **on-the-fly** by the UI thread only for the rows currently visible in the viewport.
+
+### Sorting
+- **Indirect Sorting**: We never move data in the file. Instead, we create a `sorted_indices` vector.
+- **Display Mapping**: When the UI asks for "Display Row 5", the app looks up `sorted_indices[5]` to find the "Actual Row" index in the memory map.
+
+---
+
+## 7. Key Rust Patterns
+
+- **`Arc<RwLock<T>>`**: "Atomic Reference Count" + "Read-Write Lock". Used to share the CSV data safely between the UI and background workers.
+- **`AtomicBool` / `AtomicUsize`**: High-performance, thread-safe primitives used for cancellation flags and progress counters without the overhead of a full Lock.
+- **Option/Result**: Rust's way of handling missing data and errors without ever crashing with "NullPointerExceptions".
+
+---
+
+## 8. Summary of Performance Secrets
+
+1. **Don't Copy**: Use `memmap2` to read directly from disk.
+2. **Don't Wait**: Index files in the background.
+3. **Don't Render Everything**: Only parse and draw what is visible.
+4. **Don't Block**: Always move heavy work to a thread.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2637,7 +2637,7 @@ dependencies = [
 
 [[package]]
 name = "quickcsv"
-version = "0.3.0"
+version = "0.3.2"
 dependencies = [
  "arboard",
  "csv",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quickcsv"
-version = "0.3.1"
+version = "0.3.2"
 edition = "2021"
 description = "High-performance CSV viewer for macOS"
 authors = ["QuickCSV Team"]
@@ -12,7 +12,7 @@ repository = "https://github.com/ayu5h-raj/quickcsv"
 name = "QuickCSV"
 identifier = "com.quickcsv.app"
 # icon = ["icons/icon.icns"]  # Uncomment when you have an icon
-version = "0.3.1"
+version = "0.3.2"
 copyright = "Copyright © 2026 QuickCSV Team"
 category = "Developer Tool"
 short_description = "High-performance CSV viewer"

--- a/src/main.rs
+++ b/src/main.rs
@@ -957,7 +957,7 @@ impl FastCsvApp {
                                 // Create clickable header with sort indicator
                                 let sort_indicator = if current_sort_col == Some(col_idx) {
                                     if is_sorting {
-                                        format!(" ({}%)", sort_progress)
+                                        format!(" ({sort_progress}%)")
                                     } else {
                                         match current_sort_dir {
                                             SortDirection::Ascending => " (asc)".to_string(),
@@ -969,7 +969,7 @@ impl FastCsvApp {
                                     String::new()
                                 };
 
-                                let header_text = format!("{}{}", col_name, sort_indicator);
+                                let header_text = format!("{col_name}{sort_indicator}");
 
                                 // Dim text if sorting in progress
                                 let text = if is_sorting && current_sort_col == Some(col_idx) {
@@ -1030,11 +1030,17 @@ impl FastCsvApp {
                             for (col_idx, field) in fields.iter().enumerate() {
                                 row.col(|ui| {
                                     // Check if this cell matches the search query
+                                    // Optimization: skip expensive to_lowercase on huge fields
                                     let is_match = !search_query.is_empty()
+                                        && field.len() < 100_000  // Skip search highlight on >100KB fields
                                         && field.to_lowercase().contains(&search_query);
 
-                                    // Check if this looks like JSON
+                                    // Check if this looks like JSON (optimized for large strings)
                                     let is_json = looks_like_json(field);
+
+                                    // PERFORMANCE: Truncate display string for huge fields
+                                    // Full content is still available via double-click popup
+                                    let display_text = truncate_for_display(field);
 
                                     // Create a clickable label
                                     let response = if is_match && is_current_nav_row {
@@ -1043,7 +1049,7 @@ impl FastCsvApp {
                                         ui.painter().rect_filled(rect, 2.0, CURRENT_MATCH_COLOR);
                                         ui.add(
                                             egui::Label::new(
-                                                egui::RichText::new(field).color(Color32::BLACK),
+                                                egui::RichText::new(display_text.as_ref()).color(Color32::BLACK),
                                             )
                                             .sense(egui::Sense::click()),
                                         )
@@ -1053,7 +1059,7 @@ impl FastCsvApp {
                                         ui.painter().rect_filled(rect, 2.0, HIGHLIGHT_COLOR);
                                         ui.add(
                                             egui::Label::new(
-                                                egui::RichText::new(field).color(Color32::BLACK),
+                                                egui::RichText::new(display_text.as_ref()).color(Color32::BLACK),
                                             )
                                             .sense(egui::Sense::click()),
                                         )
@@ -1061,13 +1067,13 @@ impl FastCsvApp {
                                         // JSON content - show with subtle indicator
                                         ui.add(
                                             egui::Label::new(
-                                                egui::RichText::new(field)
+                                                egui::RichText::new(display_text.as_ref())
                                                     .color(Color32::from_rgb(100, 180, 255)),
                                             )
                                             .sense(egui::Sense::click()),
                                         )
                                     } else {
-                                        ui.add(egui::Label::new(field).sense(egui::Sense::click()))
+                                        ui.add(egui::Label::new(display_text.as_ref()).sense(egui::Sense::click()))
                                     };
 
                                     // Handle double-click to open cell viewer (works for any cell)
@@ -1093,11 +1099,17 @@ impl FastCsvApp {
                                         self.json_viewer.column_name = col_name;
                                     }
 
-                                    // Show tooltip with full content on hover (for truncated cells)
-                                    // Only show if content is long enough to be truncated
-                                    // Note: on_hover_text consumes response, so this must be last
+                                    // Show tooltip for truncated cells
+                                    // Limit tooltip size to avoid performance issues with huge fields
+                                    // Full content available via double-click popup
                                     if field.len() > 50 {
-                                        response.on_hover_text(field);
+                                        if field.len() <= 500 {
+                                            response.on_hover_text(field);
+                                        } else {
+                                            // For very large fields, show truncated preview + hint
+                                            let preview: String = field.chars().take(500).collect();
+                                            response.on_hover_text(format!("{}…\n\n(Double-click to view full content: {} bytes)", preview, field.len()));
+                                        }
                                     }
                                 });
                             }
@@ -1209,7 +1221,7 @@ impl FastCsvApp {
                     // Location info with icons
                     ui.label(egui::RichText::new("📍").size(14.0));
                     ui.label(
-                        egui::RichText::new(format!("Row {}", row_num))
+                        egui::RichText::new(format!("Row {row_num}"))
                             .color(Color32::from_rgb(180, 180, 180)),
                     );
                     ui.label(egui::RichText::new("•").color(Color32::from_rgb(100, 100, 100)));
@@ -1703,10 +1715,45 @@ fn format_file_size(bytes: u64) -> String {
 }
 
 /// Check if a string looks like JSON (starts with { or [)
+/// Optimized: only checks first/last characters, doesn't scan entire string
 fn looks_like_json(s: &str) -> bool {
-    let trimmed = s.trim();
-    (trimmed.starts_with('{') && trimmed.ends_with('}'))
-        || (trimmed.starts_with('[') && trimmed.ends_with(']'))
+    // For huge strings, only check the boundaries (first 100 and last 100 chars)
+    // This avoids O(n) trim() on megabyte strings
+    let len = s.len();
+    if len == 0 {
+        return false;
+    }
+
+    // Find first non-whitespace
+    let first_char = s.bytes().take(100).find(|&b| !b.is_ascii_whitespace());
+    // Find last non-whitespace
+    let last_char = s
+        .bytes()
+        .rev()
+        .take(100)
+        .find(|&b| !b.is_ascii_whitespace());
+
+    matches!(
+        (first_char, last_char),
+        (Some(b'{'), Some(b'}')) | (Some(b'['), Some(b']'))
+    )
+}
+
+/// Truncate a string for display, keeping it short for UI performance
+/// Full content is available via double-click popup
+const MAX_DISPLAY_LEN: usize = 200;
+
+fn truncate_for_display(s: &str) -> std::borrow::Cow<'_, str> {
+    if s.len() <= MAX_DISPLAY_LEN {
+        std::borrow::Cow::Borrowed(s)
+    } else {
+        // Find a safe UTF-8 boundary
+        let mut end = MAX_DISPLAY_LEN;
+        while end > 0 && !s.is_char_boundary(end) {
+            end -= 1;
+        }
+        std::borrow::Cow::Owned(format!("{}…", &s[..end]))
+    }
 }
 
 /// Find the next row boundary in CSV data, respecting quoted fields.


### PR DESCRIPTION
Problem:
- CSV files with 600KB-1.2MB JSON fields caused scroll lag
- Full megabyte strings were passed to egui for text layout
- Expensive to_lowercase() called on huge strings for search
- Vec<String> cloning overhead on cache hits

Solution:
- Add truncate_for_display() to limit cell text to 200 chars
- Optimize looks_like_json() to only check first/last 100 bytes
- Skip search highlighting on fields >100KB
- Limit tooltip preview to 500 chars with double-click hint

Full content remains accessible via double-click cell viewer popup.

Bumps version to 0.3.2