### PR TITLE
chore: bump version to 0.10.5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quickcsv"
-version = "0.10.4"
+version = "0.10.5"
 edition = "2021"
 description = "High-performance CSV viewer for macOS and Web"
 authors = ["QuickCSV Team"]
@@ -22,7 +22,7 @@ path = "src/main.rs"
 name = "QuickCSV"
 identifier = "com.quickcsv.app"
 icon = ["icons/icon.icns"]
-version = "0.10.4"
+version = "0.10.5"
 osx_info_plist_exts = ["macos/file-associations.plist"]
 copyright = "Copyright © 2026 QuickCSV Team"
 category = "Developer Tool"


### PR DESCRIPTION
## Summary
- Bump version from 0.10.4 to 0.10.5 (both `package.version` and `package.metadata.bundle.version`)

## Included in this release
- fix: support macOS CSV file associations and Finder open flow (#28)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bump version to 0.10.5 to ship the macOS CSV file association and Finder open fix. Updates both the crate version and the macOS bundle version in Cargo.toml.

- **Bug Fixes**
  - macOS: CSV files now associate with the app and open correctly from Finder (#28).

<sup>Written for commit ff644067c190c46872ba39b09d5ef4e123d6f06d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

