### PR TITLE
ci: push traffic data with GITHUB_TOKEN

### DIFF
--- a/.github/workflows/traffic.yml
+++ b/.github/workflows/traffic.yml
@@ -8,10 +8,10 @@ on:
     - cron: "17 4 * * *" # daily at 04:17 UTC
   workflow_dispatch:
 
-# Read-only on main; all writes go to the unprotected traffic-data branch via
-# the PAT below, so no elevated permissions are needed here.
+# GITHUB_TOKEN needs write to push the data commit to the (unprotected)
+# traffic-data branch. The PAT is used only to read the traffic API.
 permissions:
-  contents: read
+  contents: write
 
 jobs:
   track:
@@ -26,7 +26,9 @@ jobs:
         with:
           ref: traffic-data
           path: data
-          token: ${{ secrets.TRAFFIC_TOKEN }} # PAT so the push below is allowed
+          # Uses the default GITHUB_TOKEN (contents: write) so the push below
+          # is allowed. traffic-data is unprotected, so no PAT push rights are
+          # needed — the read-only TRAFFIC_TOKEN is only for the API fetch.
 
       - name: Fetch traffic and release data
         # The traffic API requires push/admin access, which the built-in


### PR DESCRIPTION
## Problem

After moving data to the `traffic-data` branch (#32), the dispatch run committed but failed to push:

\`\`\`
remote: Permission to ayu5h-raj/quickcsv.git denied to ayu5h-raj.
fatal: ... error: 403
\`\`\`

The `TRAFFIC_TOKEN` PAT is **read-only** — fine for reading the traffic API, but it can't push.

## Fix

Use the built-in **`GITHUB_TOKEN`** (`contents: write`) for the push, and keep the PAT read-only and used only for the API fetch:

- Top-level `permissions: contents: write`.
- The `traffic-data` checkout drops the PAT `token:` override, so it persists `GITHUB_TOKEN` credentials for the push.
- `traffic-data` is unprotected (not in the `main` ruleset), so `GITHUB_TOKEN` can push to it.

This keeps your PAT minimal (read-only) — no token changes needed on your end.

## Verification

Dispatch after merge and confirm a `chore: update traffic history` commit lands on `traffic-data`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix push failures to `traffic-data` by using `GITHUB_TOKEN` with `contents: write`, while keeping the read-only `TRAFFIC_TOKEN` only for fetching the traffic API. Sets workflow `permissions: contents: write` and removes the PAT override on the `traffic-data` checkout so the push succeeds.

<sup>Written for commit ad8a6784bbd5c360e1c731e788e3dbffd39b11c6. Summary will update on new commits. <a href="https://cubic.dev/pr/ayu5h-raj/quickcsv/pull/33?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

