### PR TITLE
feat: self-host web app on VPS + auto-deploy, redirect Pages to www.quickcsv.in

### DIFF
--- a/.github/workflows/deploy-vps.yml
+++ b/.github/workflows/deploy-vps.yml
@@ -1,0 +1,34 @@
+name: Deploy Web to VPS
+
+# Rebuilds and redeploys the self-hosted web app at https://www.quickcsv.in
+# on the VPS whenever a release tag is pushed. Can also be run manually.
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-vps
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy over SSH
+        uses: appleboy/ssh-action@v1.2.0
+        with:
+          host: ${{ secrets.VPS_HOST }}
+          username: ${{ secrets.VPS_USER }}
+          key: ${{ secrets.VPS_SSH_KEY }}
+          command_timeout: 30m
+          script: |
+            set -euo pipefail
+            cd /opt/quickcsv
+            git fetch --all --prune
+            git checkout main
+            git reset --hard origin/main
+            docker compose up -d --build
+            docker image prune -f
+            echo "Deployed commit: $(git rev-parse --short HEAD)"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -153,6 +153,8 @@ jobs:
           git commit -m "Update QuickCSV to ${VERSION}"
           git push
 
+  # The web app is now self-hosted on the VPS at https://quickcsv.in.
+  # GitHub Pages just redirects there (keeps the old github.io URL working).
   build-deploy-web:
     needs: update-homebrew
     runs-on: ubuntu-latest
@@ -160,24 +162,34 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@v4
-      
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: wasm32-unknown-unknown
-          
-      - name: Install Trunk
-        uses: jetli/trunk-action@v0.5.0
-        with:
-          version: 'latest'
-          
-      - name: Build WASM
-        run: trunk build --release --public-url /quickcsv/
-        
-      - name: Add .nojekyll
-        run: touch dist/.nojekyll
-        
-      - name: Deploy to GitHub Pages
+
+      - name: Build redirect page
+        run: |
+          mkdir -p dist
+          touch dist/.nojekyll
+          cat > dist/index.html <<'EOF'
+          <!DOCTYPE html>
+          <html lang="en">
+          <head>
+            <meta charset="utf-8">
+            <meta name="viewport" content="width=device-width, initial-scale=1">
+            <title>QuickCSV has moved to quickcsv.in</title>
+            <link rel="canonical" href="https://quickcsv.in/">
+            <meta http-equiv="refresh" content="0; url=https://quickcsv.in/">
+            <script>window.location.replace("https://quickcsv.in/");</script>
+            <style>
+              body { font-family: -apple-system, system-ui, sans-serif; background:#202020;
+                     color:#e0e0e0; display:grid; place-items:center; height:100vh; margin:0; }
+              a { color:#4ea1ff; }
+            </style>
+          </head>
+          <body>
+            <p>QuickCSV now lives at <a href="https://quickcsv.in/">quickcsv.in</a> — redirecting…</p>
+          </body>
+          </html>
+          EOF
+
+      - name: Deploy redirect to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -153,7 +153,7 @@ jobs:
           git commit -m "Update QuickCSV to ${VERSION}"
           git push
 
-  # The web app is now self-hosted on the VPS at https://quickcsv.in.
+  # The web app is now self-hosted on the VPS at https://www.quickcsv.in.
   # GitHub Pages just redirects there (keeps the old github.io URL working).
   build-deploy-web:
     needs: update-homebrew
@@ -173,10 +173,10 @@ jobs:
           <head>
             <meta charset="utf-8">
             <meta name="viewport" content="width=device-width, initial-scale=1">
-            <title>QuickCSV has moved to quickcsv.in</title>
-            <link rel="canonical" href="https://quickcsv.in/">
-            <meta http-equiv="refresh" content="0; url=https://quickcsv.in/">
-            <script>window.location.replace("https://quickcsv.in/");</script>
+            <title>QuickCSV has moved to www.quickcsv.in</title>
+            <link rel="canonical" href="https://www.quickcsv.in/">
+            <meta http-equiv="refresh" content="0; url=https://www.quickcsv.in/">
+            <script>window.location.replace("https://www.quickcsv.in/");</script>
             <style>
               body { font-family: -apple-system, system-ui, sans-serif; background:#202020;
                      color:#e0e0e0; display:grid; place-items:center; height:100vh; margin:0; }
@@ -184,7 +184,7 @@ jobs:
             </style>
           </head>
           <body>
-            <p>QuickCSV now lives at <a href="https://quickcsv.in/">quickcsv.in</a> — redirecting…</p>
+            <p>QuickCSV now lives at <a href="https://www.quickcsv.in/">www.quickcsv.in</a> — redirecting…</p>
           </body>
           </html>
           EOF

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,37 @@
+# Stage 1: Build the WASM web app with Trunk
+FROM rust:slim-bookworm AS builder
+
+# Build dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    pkg-config \
+    libssl-dev \
+    ca-certificates \
+    git \
+    && rm -rf /var/lib/apt/lists/*
+
+# WASM target + Trunk
+RUN rustup target add wasm32-unknown-unknown
+RUN cargo install --locked trunk wasm-bindgen-cli
+
+WORKDIR /app
+
+# Manifests first (better layer caching)
+COPY Cargo.toml Cargo.lock Trunk.toml ./
+
+# Source and assets
+COPY src ./src
+COPY icons ./icons
+COPY index.html ./
+
+# Build the optimized release WASM bundle.
+# Served at the domain root on the VPS, so no --public-url prefix.
+RUN trunk build --release
+
+# Stage 2: Serve the static bundle with Nginx
+FROM nginx:alpine
+
+COPY --from=builder /app/dist /usr/share/nginx/html
+
+EXPOSE 80
+
+CMD ["nginx", "-g", "daemon off;"]

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A blazing-fast CSV viewer for macOS that handles files from 100MB to 2GB+ with z
 ![Platform](https://img.shields.io/badge/platform-macOS-blue.svg)
 ![License](https://img.shields.io/badge/license-MIT-green.svg)
 
-🌐 **Try it in your browser:** [https://ayu5h-raj.github.io/quickcsv/](https://ayu5h-raj.github.io/quickcsv/) *(Note: Web version loads files into RAM, unlike desktop which uses memory-mapped I/O)*
+🌐 **Try it in your browser:** [https://www.quickcsv.in/](https://www.quickcsv.in/) *(Note: Web version loads files into RAM, unlike desktop which uses memory-mapped I/O)*
 
 ## Features
 
@@ -50,7 +50,7 @@ Download the latest `QuickCSV.app` from the [Releases page](https://github.com/a
 
 ### Try Web Version
 
-You can try QuickCSV in your browser at **[https://ayu5h-raj.github.io/quickcsv/](https://ayu5h-raj.github.io/quickcsv/)**.
+You can try QuickCSV in your browser at **[https://www.quickcsv.in/](https://www.quickcsv.in/)**.
 
 > **Note:** The web version is not as efficient as the desktop version due to browser limitations, but it's great for trying out QuickCSV without installation. On a MacBook M2 Air, files typically open in a few seconds.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,18 @@
+# Production deployment for the QuickCSV web app on the VPS.
+# Sits behind the existing Traefik reverse proxy (project: traefik-qmwd),
+# which terminates TLS via the `letsencrypt` resolver and redirects HTTP->HTTPS.
+# Traefik runs on the host network and reaches this container over its bridge IP,
+# so no host port needs to be published.
+services:
+  quickcsv:
+    build: .
+    container_name: quickcsv
+    restart: unless-stopped
+    expose:
+      - "80"
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.quickcsv.rule=Host(`quickcsv.in`) || Host(`www.quickcsv.in`)"
+      - "traefik.http.routers.quickcsv.entrypoints=websecure"
+      - "traefik.http.routers.quickcsv.tls.certresolver=letsencrypt"
+      - "traefik.http.services.quickcsv.loadbalancer.server.port=80"


### PR DESCRIPTION
## Summary
Self-hosts the QuickCSV web app on the VPS behind the existing Traefik proxy, served at **https://www.quickcsv.in** (and apex `quickcsv.in`) with an auto-renewing Let's Encrypt cert. GitHub Pages now just redirects to `www.quickcsv.in`.

## Changes
- **Dockerfile** — multi-stage WASM build (bumped to `rust:slim-bookworm` to avoid MSRV failures vs `Cargo.lock`), served by nginx; built at domain root (no `--public-url`).
- **docker-compose.yml** — attaches the container to the existing Traefik proxy via labels (`Host(quickcsv.in) || Host(www.quickcsv.in)`, `letsencrypt` resolver), no published host port.
- **.github/workflows/deploy-vps.yml** — on version tag `v*` (and manual dispatch), SSHes into the VPS and runs `git pull` + `docker compose up -d --build`. Uses secrets `VPS_HOST` / `VPS_USER` / `VPS_SSH_KEY`.
- **.github/workflows/release.yml** — Pages job now publishes a redirect to `https://www.quickcsv.in/` instead of the app.
- **README.md** — browser links point to `https://www.quickcsv.in/`.

## Status (already live)
- App deployed and verified at `https://www.quickcsv.in` / `https://quickcsv.in` (HTTP/2 200, valid LE cert).
- `gh-pages` already updated to redirect immediately.
- Deploy SSH key installed on VPS; GitHub secrets configured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Self-host the QuickCSV web app on our VPS behind `Traefik` with HTTPS and tag-based auto-deploy. `quickcsv.in` and `www.quickcsv.in` now serve the app; GitHub Pages only redirects.

- New Features
  - Dockerfile: multi-stage WASM build on `rust:slim-bookworm`, served by `nginx` at domain root.
  - docker-compose.yml: attach to existing `Traefik` with hosts `quickcsv.in`/`www.quickcsv.in`, TLS via `letsencrypt`, no host port.
  - .github/workflows/deploy-vps.yml: deploy on `v*` tags or manual via `appleboy/ssh-action@v1.2.0`; SSH, reset to main, `docker compose up -d --build`, prune; uses `VPS_HOST`/`VPS_USER`/`VPS_SSH_KEY`.
  - .github/workflows/release.yml: replace Pages build with a single redirect page via `peaceiris/actions-gh-pages@v3`.
  - README: update browser links to `https://www.quickcsv.in/`.

<sup>Written for commit ad9e50160c268466cc09ae2b095542a065fbbd29. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ayu5h-raj/quickcsv/pull/35?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

