### PR TITLE
feat: auto-reload open files when changed externally

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -134,7 +134,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef6978589202a00cd7e118380c448a08b6ed394c3a8df3a430d0898e3a42d046"
 dependencies = [
  "android-properties",
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "cc",
  "cesu8",
  "jni",
@@ -476,9 +476,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.10.0"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
 name = "block"
@@ -561,7 +561,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b99da2f8558ca23c71f4fd15dc57c906239752dd27ff3c00a1d56b685b7cbfec"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "log",
  "polling",
  "rustix 0.38.44",
@@ -575,7 +575,7 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb9f6e1368bd4621d2c86baa7e37de77a938adf5221e5dd3d6133340101b309e"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "polling",
  "rustix 1.1.3",
  "slab",
@@ -750,7 +750,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d44a101f213f6c4cdc1853d4b78aef6db6bdfa3468798cc1d9912f4735013eb"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "core-foundation 0.10.1",
  "libc",
 ]
@@ -836,7 +836,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89a09f22a6c6069a18470eb92d2298acf25463f14256d24778e1230d789a2aec"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "block2 0.6.2",
  "libc",
  "objc2 0.6.3",
@@ -936,7 +936,7 @@ checksum = "6a9b567d356674e9a5121ed3fedfb0a7c31e059fe71f6972b691bcd0bfc284e3"
 dependencies = [
  "accesskit",
  "ahash",
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "emath",
  "epaint",
  "log",
@@ -1251,6 +1251,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fsevent-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1381,7 +1390,7 @@ version = "0.32.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12124de845cacfebedff80e877bb37b5b75c34c5a4c89e47e1cdd67fb6041325"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "cfg_aliases",
  "cgl",
  "dispatch2",
@@ -1447,7 +1456,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fbcd2dba93594b227a1f57ee09b8b9da8892c34d55aa332e034a228d0fe6a171"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "gpu-alloc-types",
 ]
 
@@ -1457,7 +1466,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98ff03b468aa837d70984d55f5d3f846f6ec31fe34bbb97c4f85219caeee1ca4"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
 ]
 
 [[package]]
@@ -1478,7 +1487,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b89c83349105e3732062a895becfc71a8f921bb71ecbbdd8ff99263e3b53a0ca"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "gpu-descriptor-types",
  "hashbrown 0.15.5",
 ]
@@ -1489,7 +1498,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdf242682df893b86f33a73828fb09ca4b2d3bb6cc95249707fc684d27484b91"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
 ]
 
 [[package]]
@@ -1692,6 +1701,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "inotify"
+version = "0.11.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cc00ea907cab49550b7da656f80ebb97be1b997d931fbcd28d39734e17ce592"
+dependencies = [
+ "bitflags 2.13.1",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c033f80b2c113cdf91ab7a33faa9cbc014726dcad99880c8609af2a370edf37d"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1757,10 +1786,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2db585e1d738fc771bf08a151420d3ed193d9d895a36df7f6f8a9456b911ddc"
 
 [[package]]
-name = "libc"
-version = "0.2.178"
+name = "kqueue"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37c93d8daa9d8a012fd8ab92f088405fb202ea0b6ab73ee2482ae66af4f42091"
+checksum = "8d763e5b24120b4ddf50de6c92308156765aabfbbccebf401da7cff2d70a41ea"
+dependencies = [
+ "kqueue-sys",
+ "libc",
+]
+
+[[package]]
+name = "kqueue-sys"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07293a4e297ac234359b510362495713f75ea345d5307140414f20c69ffeb087"
+dependencies = [
+ "bitflags 2.13.1",
+ "libc",
+]
+
+[[package]]
+name = "libc"
+version = "0.2.189"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "libloading"
@@ -1784,7 +1833,7 @@ version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "libc",
  "redox_syscall 0.7.0",
 ]
@@ -1867,7 +1916,7 @@ version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00c15a6f673ff72ddcc22394663290f870fb224c1bfce55734a75c414150e605"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "block",
  "core-graphics-types 0.2.0",
  "foreign-types",
@@ -1905,6 +1954,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "mio"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
+dependencies = [
+ "libc",
+ "log",
+ "wasi",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "moxcms"
 version = "0.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1922,7 +1983,7 @@ checksum = "066cf25f0e8b11ee0df221219010f213ad429855f57c494f995590c861a9a7d8"
 dependencies = [
  "arrayvec",
  "bit-set",
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "cfg-if",
  "cfg_aliases",
  "codespan-reporting",
@@ -1946,7 +2007,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3f42e7bbe13d351b6bead8286a43aac9534b82bd3cc43e47037f012ebfd62d4"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "jni-sys",
  "log",
  "ndk-sys",
@@ -1976,7 +2037,7 @@ version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -1988,6 +2049,33 @@ name = "nohash-hasher"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
+
+[[package]]
+name = "notify"
+version = "8.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3"
+dependencies = [
+ "bitflags 2.13.1",
+ "fsevent-sys",
+ "inotify",
+ "kqueue",
+ "libc",
+ "log",
+ "mio",
+ "notify-types",
+ "walkdir",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "notify-types"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42b8cfee0e339a0337359f3c88165702ac6e600dc01c0cc9579a92d62b08477a"
+dependencies = [
+ "bitflags 2.13.1",
+]
 
 [[package]]
 name = "num-traits"
@@ -2061,7 +2149,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4e89ad9e3d7d297152b17d39ed92cd50ca8063a89a9fa569046d41568891eff"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "block2 0.5.1",
  "libc",
  "objc2 0.5.2",
@@ -2077,7 +2165,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "block2 0.6.2",
  "objc2 0.6.3",
  "objc2-core-foundation",
@@ -2091,7 +2179,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74dd3b56391c7a0596a295029734d3c1c5e7e510a4cb30245f8221ccea96b009"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-core-location",
@@ -2115,7 +2203,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "617fbf49e071c178c0b24c080767db52958f716d9eabdf0890523aeae54773ef"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-foundation 0.2.2",
@@ -2127,7 +2215,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "dispatch2",
  "objc2 0.6.3",
 ]
@@ -2138,7 +2226,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "dispatch2",
  "objc2 0.6.3",
  "objc2-core-foundation",
@@ -2181,7 +2269,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ee638a5da3799329310ad4cfa62fbf045d5f56e3ef5ba4149e7452dcf89d5a8"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "block2 0.5.1",
  "dispatch",
  "libc",
@@ -2194,7 +2282,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "objc2 0.6.3",
  "objc2-core-foundation",
 ]
@@ -2205,7 +2293,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "objc2 0.6.3",
  "objc2-core-foundation",
 ]
@@ -2228,7 +2316,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd0cba1276f6023976a406a14ffa85e1fdd19df6b0f737b063b95f6c8c7aadd6"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-foundation 0.2.2",
@@ -2240,7 +2328,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e42bee7bff906b14b167da2bac5efe6b6a07e6f7c0a21a7308d40c960242dc7a"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-foundation 0.2.2",
@@ -2263,7 +2351,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8bb46798b20cd6b91cbd113524c490f1686f4c4e8f49502431415f3512e2b6f"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-cloud-kit",
@@ -2295,7 +2383,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76cfcbf642358e8689af64cee815d139339f3ed8ad05103ed5eaf73db8d84cb3"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-core-location",
@@ -2491,7 +2579,7 @@ version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97baced388464909d42d89643fe4361939af9b7ce7a31ee32a168f832a70f2a0"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "crc32fast",
  "fdeflate",
  "flate2",
@@ -2632,6 +2720,7 @@ dependencies = [
  "js-sys",
  "memchr",
  "memmap2",
+ "notify",
  "objc2 0.5.2",
  "objc2-app-kit 0.2.2",
  "objc2-foundation 0.2.2",
@@ -2733,7 +2822,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
 ]
 
 [[package]]
@@ -2742,7 +2831,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49f3fe0889e69e2ae9e41f4d6c4c0181701d00e4697b356fb1f74173a5e0ee27"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
 ]
 
 [[package]]
@@ -2818,7 +2907,7 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
@@ -2831,7 +2920,7 @@ version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
@@ -3039,7 +3128,7 @@ version = "0.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3457dea1f0eb631b4034d61d4d8c32074caa6cd1ab2d59f2327bd8461e2c0016"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "calloop 0.13.0",
  "calloop-wayland-source 0.3.0",
  "cursor-icon",
@@ -3064,7 +3153,7 @@ version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0512da38f5e2b31201a93524adb8d3136276fa4fe4aafab4e1f727a82b534cc0"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "calloop 0.14.3",
  "calloop-wayland-source 0.4.1",
  "cursor-icon",
@@ -3111,7 +3200,7 @@ version = "0.3.0+sdk-1.3.268.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eda41003dc44290527a59b13432d4a0379379fa074b70174882adfbdfd917844"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
 ]
 
 [[package]]
@@ -3568,7 +3657,7 @@ version = "0.31.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8e6faa537fbb6c186cb9f1d41f2f811a4120d1b57ec61f50da451a0c5122bec"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "rustix 1.1.3",
  "wayland-backend",
  "wayland-scanner",
@@ -3580,7 +3669,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "625c5029dbd43d25e6aa9615e88b829a5cad13b2819c4ae129fdbb7c31ab4c7e"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "cursor-icon",
  "wayland-backend",
 ]
@@ -3602,7 +3691,7 @@ version = "0.32.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baeda9ffbcfc8cd6ddaade385eaf2393bd2115a69523c735f12242353c3df4f3"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "wayland-backend",
  "wayland-client",
  "wayland-scanner",
@@ -3614,7 +3703,7 @@ version = "20250721.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40a1f863128dcaaec790d7b4b396cc9b9a7a079e878e18c47e6c2d2c5a8dcbb1"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "wayland-backend",
  "wayland-client",
  "wayland-protocols",
@@ -3627,7 +3716,7 @@ version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "791c58fdeec5406aa37169dd815327d1e47f334219b523444bc26d70ceb4c34e"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "wayland-backend",
  "wayland-client",
  "wayland-protocols",
@@ -3640,7 +3729,7 @@ version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa98634619300a535a9a97f338aed9a5ff1e01a461943e8346ff4ae26007306b"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "wayland-backend",
  "wayland-client",
  "wayland-protocols",
@@ -3653,7 +3742,7 @@ version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9597cdf02cf0c34cd5823786dce6b5ae8598f05c2daf5621b6e178d4f7345f3"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "wayland-backend",
  "wayland-client",
  "wayland-protocols",
@@ -3741,7 +3830,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfe68bac7cde125de7a731c3400723cadaaf1703795ad3f4805f187459cd7a77"
 dependencies = [
  "arrayvec",
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "cfg-if",
  "cfg_aliases",
  "document-features",
@@ -3772,7 +3861,7 @@ dependencies = [
  "arrayvec",
  "bit-set",
  "bit-vec",
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "bytemuck",
  "cfg_aliases",
  "document-features",
@@ -3832,7 +3921,7 @@ dependencies = [
  "arrayvec",
  "ash",
  "bit-set",
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "block",
  "bytemuck",
  "cfg-if",
@@ -3877,7 +3966,7 @@ version = "27.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "afdcf84c395990db737f2dd91628706cb31e86d72e53482320d368e52b5da5eb"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "bytemuck",
  "js-sys",
  "log",
@@ -4403,7 +4492,7 @@ dependencies = [
  "ahash",
  "android-activity",
  "atomic-waker",
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "block2 0.5.1",
  "bytemuck",
  "calloop 0.13.0",
@@ -4511,7 +4600,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d039de8032a9a8856a6be89cea3e5d12fdd82306ab7c94d74e6deab2460651c5"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "dlib",
  "log",
  "once_cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,6 +70,8 @@ rfd = "0.16"
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 # Memory-mapped file I/O for zero-copy loading
 memmap2 = "0.9"
+# Filesystem notifications for auto-reload on external file changes
+notify = "8.2"
 # Config directory access
 dirs = "5.0"
 

--- a/src/csv/parser.rs
+++ b/src/csv/parser.rs
@@ -76,7 +76,7 @@ pub fn find_row_boundary(bytes: &[u8], start: usize) -> Option<usize> {
 /// 3. Pick the delimiter that appears most consistently across lines
 /// 4. Fall back to comma if no clear winner
 pub fn detect_delimiter(bytes: &[u8]) -> u8 {
-    const CANDIDATES: [u8; 4] = [b',', b'\t', b';', b'|'];
+    const CANDIDATES: [u8; 4] = *b",\t;|";
     const MAX_LINES: usize = 5;
     const MAX_BYTES: usize = 10000; // Don't scan too much
 

--- a/src/file_watcher.rs
+++ b/src/file_watcher.rs
@@ -1,0 +1,205 @@
+//! Filesystem watcher for detecting external changes to open CSV files.
+//!
+//! Native only - web builds load files into browser memory and cannot watch
+//! the filesystem, so auto-reload is a desktop-only feature.
+
+use notify::{Event, EventKind, RecommendedWatcher, RecursiveMode, Watcher};
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::mpsc;
+use std::time::{Duration, Instant};
+
+use eframe::egui;
+
+/// Minimum time between two auto-reloads of the same file (debounce).
+///
+/// Editors frequently emit several events for a single save (truncate, write,
+/// metadata, rename), so we collapse them into one reload.
+const RELOAD_DEBOUNCE: Duration = Duration::from_millis(500);
+
+/// Whether a filesystem event indicates the file's contents may have changed.
+///
+/// Pure function so it can be unit-tested without a live watcher.
+fn is_content_change(event: &Event) -> bool {
+    use notify::event::ModifyKind;
+    match event.kind {
+        EventKind::Create(_) | EventKind::Remove(_) => true,
+        EventKind::Modify(ModifyKind::Data(_)) | EventKind::Modify(ModifyKind::Name(_)) => true,
+        EventKind::Modify(ModifyKind::Any) => true,
+        // Metadata-only changes (mtime/chmod) are not content changes.
+        EventKind::Modify(ModifyKind::Metadata(_)) => false,
+        _ => false,
+    }
+}
+
+/// Tracks open files and reports which ones changed on disk.
+///
+/// Watches the parent directory of each open file (rather than the file
+/// itself) so atomic saves - where an editor replaces the file via rename -
+/// are still detected. Events are filtered to the files we actually care about
+/// and debounced to avoid duplicate reloads.
+pub struct FileWatcher {
+    /// The notify watcher driving events (kept alive for the struct's lifetime).
+    watcher: RecommendedWatcher,
+    /// Receives raw filesystem events from the notify thread.
+    rx: mpsc::Receiver<notify::Result<Event>>,
+    /// Canonical file path -> the original path it was registered under.
+    watched: HashMap<PathBuf, PathBuf>,
+    /// Timestamp of the last reported change per file (for debouncing).
+    last_reported: HashMap<PathBuf, Instant>,
+}
+
+impl FileWatcher {
+    /// Create a watcher. Events request a repaint on `ctx` so the UI thread
+    /// wakes up and can drain the queued changes.
+    pub fn new(ctx: egui::Context) -> Result<Self, notify::Error> {
+        let (tx, rx) = mpsc::channel();
+        let watcher = notify::recommended_watcher(move |res: notify::Result<Event>| {
+            ctx.request_repaint();
+            let _ = tx.send(res);
+        })?;
+        Ok(Self {
+            watcher,
+            rx,
+            watched: HashMap::new(),
+            last_reported: HashMap::new(),
+        })
+    }
+
+    /// Start watching `path` (by registering its parent directory).
+    pub fn register(&mut self, path: &Path) {
+        let Ok(canonical) = path.canonicalize() else {
+            return;
+        };
+        if self.watched.contains_key(&canonical) {
+            return;
+        }
+        let original = path.to_path_buf();
+        self.watched.insert(canonical.clone(), original);
+
+        let Some(parent) = canonical.parent() else {
+            return;
+        };
+        // Best-effort: ignore errors (e.g. directory disappearing).
+        let _ = self.watcher.watch(parent, RecursiveMode::NonRecursive);
+    }
+
+    /// Stop watching the file at `path`, unwatching its parent directory when
+    /// no other registered file lives there anymore.
+    pub fn unregister(&mut self, path: &Path) {
+        let canonical = match path.canonicalize() {
+            Ok(c) => c,
+            // File may already be gone; match by the original registered path.
+            Err(_) => {
+                let key = self
+                    .watched
+                    .iter()
+                    .find(|(_, original)| original.as_path() == path)
+                    .map(|(canonical, _)| canonical.clone());
+                match key {
+                    Some(key) => key,
+                    None => return,
+                }
+            }
+        };
+
+        if self.watched.remove(&canonical).is_none() {
+            return;
+        }
+        self.last_reported.remove(&canonical);
+
+        let Some(parent) = canonical.parent() else {
+            return;
+        };
+        let still_used = self.watched.keys().any(|p| p.parent() == Some(parent));
+        if !still_used {
+            let _ = self.watcher.unwatch(parent);
+        }
+    }
+
+    /// Drain pending events and return the canonical paths of files that
+    /// changed on disk and are currently registered.
+    pub fn changed_files(&mut self, now: Instant) -> Vec<PathBuf> {
+        let mut changed = Vec::new();
+        while let Ok(res) = self.rx.try_recv() {
+            let Ok(event) = res else {
+                continue;
+            };
+            if !is_content_change(&event) {
+                continue;
+            }
+            for path in event.paths {
+                let Ok(canonical) = path.canonicalize() else {
+                    // File no longer exists - keep showing the last known data.
+                    continue;
+                };
+                if !self.watched.contains_key(&canonical) {
+                    continue;
+                }
+                let debounced = self
+                    .last_reported
+                    .get(&canonical)
+                    .is_some_and(|t| now.duration_since(*t) < RELOAD_DEBOUNCE);
+                if debounced {
+                    continue;
+                }
+                self.last_reported.insert(canonical.clone(), now);
+                if !changed.contains(&canonical) {
+                    changed.push(canonical);
+                }
+            }
+        }
+        changed
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use notify::event::{AccessKind, CreateKind, DataChange, MetadataKind, ModifyKind, RemoveKind};
+
+    fn event(kind: EventKind) -> Event {
+        Event {
+            kind,
+            paths: vec![PathBuf::from("/tmp/example.csv")],
+            attrs: notify::event::EventAttributes::default(),
+        }
+    }
+
+    #[test]
+    fn data_modifications_are_content_changes() {
+        assert!(is_content_change(&event(EventKind::Modify(
+            ModifyKind::Data(DataChange::Any)
+        ))));
+        assert!(is_content_change(&event(EventKind::Modify(
+            ModifyKind::Data(DataChange::Content)
+        ))));
+        assert!(is_content_change(&event(EventKind::Modify(
+            ModifyKind::Any
+        ))));
+    }
+
+    #[test]
+    fn create_remove_and_rename_are_content_changes() {
+        assert!(is_content_change(&event(EventKind::Create(
+            CreateKind::File
+        ))));
+        assert!(is_content_change(&event(EventKind::Remove(
+            RemoveKind::File
+        ))));
+        assert!(is_content_change(&event(EventKind::Modify(
+            ModifyKind::Name(notify::event::RenameMode::Any)
+        ))));
+    }
+
+    #[test]
+    fn metadata_and_access_events_are_not_content_changes() {
+        assert!(!is_content_change(&event(EventKind::Modify(
+            ModifyKind::Metadata(MetadataKind::Any)
+        ))));
+        assert!(!is_content_change(&event(EventKind::Access(
+            AccessKind::Read
+        ))));
+        assert!(!is_content_change(&event(EventKind::Other)));
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,8 @@
 // Module declarations
 mod analytics;
 mod csv;
+#[cfg(not(target_arch = "wasm32"))]
+mod file_watcher;
 mod state;
 mod update;
 mod utils;
@@ -29,13 +31,15 @@ use std::sync::{mpsc, Arc};
 #[cfg(not(target_arch = "wasm32"))]
 use std::thread;
 #[cfg(not(target_arch = "wasm32"))]
-use std::time::Duration;
+use std::time::{Duration, Instant};
 #[cfg(target_arch = "wasm32")]
 use wasm_bindgen::JsCast;
 
 // Imports from modules
 #[cfg(not(target_arch = "wasm32"))]
 use csv::init_csv_progressive;
+#[cfg(not(target_arch = "wasm32"))]
+use file_watcher::FileWatcher;
 use state::{
     ColumnState, FilterCondition, FilterOperator, FilterState, LoadState, SearchStatus,
     SortDirection, SortState, TabState, MAX_NAV_ROWS,
@@ -361,6 +365,9 @@ struct FastCsvApp {
     /// Whether window has been expanded after file load
     #[allow(dead_code)] // Used in native code only
     window_expanded: bool,
+    /// Watches open files for external changes and queues auto-reloads
+    #[cfg(not(target_arch = "wasm32"))]
+    file_watcher: Option<FileWatcher>,
     /// Whether keyboard shortcuts dialog is open
     shortcuts_dialog_open: bool,
     /// Channel for receiving loaded file data from async web tasks (WASM)
@@ -387,6 +394,8 @@ impl Default for FastCsvApp {
             recent_files: RecentFiles::default(),
             recent_files_loaded: false,
             window_expanded: false,
+            #[cfg(not(target_arch = "wasm32"))]
+            file_watcher: None,
             shortcuts_dialog_open: false,
             #[cfg(target_arch = "wasm32")]
             file_loader_tx: tx,
@@ -657,7 +666,23 @@ impl FastCsvApp {
     #[cfg(not(target_arch = "wasm32"))]
     fn load_file(&mut self, path: PathBuf, ctx: egui::Context) {
         self.ensure_tabs();
-        let tab = self.active_tab_mut();
+        let idx = self.active_tab_index;
+        self.load_file_into_tab(idx, path.clone(), ctx);
+        self.register_file_watcher(&path);
+        let name = self.tabs[idx].file_name.clone();
+        self.recent_files
+            .add_file(path.to_string_lossy().to_string(), name);
+        self.save_recent_files();
+    }
+
+    /// Load a CSV file into a specific tab in the background (Native)
+    ///
+    /// Shared by initial opens and auto-reloads when a file changes on disk.
+    /// Does not touch recent files or the file watcher - callers handle that.
+    #[cfg(not(target_arch = "wasm32"))]
+    fn load_file_into_tab(&mut self, idx: usize, path: PathBuf, ctx: egui::Context) {
+        self.ensure_tabs();
+        let tab = &mut self.tabs[idx];
 
         // Reset state
         tab.scroll_y = 0.0;
@@ -724,10 +749,6 @@ impl FastCsvApp {
         tab.file_path = path_str.clone();
         tab.file_name = file_name.clone();
 
-        // Add to recent files
-        self.recent_files.add_file(path_str, file_name);
-        self.save_recent_files();
-
         // Start progressive loading - shows data immediately while indexing continues
         thread::spawn(move || {
             let result = init_csv_progressive(&path_clone, &state, &ctx);
@@ -739,6 +760,62 @@ impl FastCsvApp {
                 ctx.request_repaint();
             }
         });
+    }
+
+    /// Register a loaded file with the watcher so external changes trigger a reload
+    #[cfg(not(target_arch = "wasm32"))]
+    fn register_file_watcher(&mut self, path: &Path) {
+        if let Some(watcher) = self.file_watcher.as_mut() {
+            watcher.register(path);
+        }
+    }
+
+    /// Initialize the file watcher with the UI context so events wake the UI thread
+    #[cfg(not(target_arch = "wasm32"))]
+    fn init_file_watcher(&mut self, ctx: egui::Context) {
+        self.file_watcher = FileWatcher::new(ctx).ok();
+    }
+
+    /// Stop watching a file (e.g. when its tab is closed)
+    #[cfg(not(target_arch = "wasm32"))]
+    fn unregister_file_watcher(&mut self, path: &str) {
+        if let Some(watcher) = self.file_watcher.as_mut() {
+            watcher.unregister(Path::new(path));
+        }
+    }
+
+    /// Reload tabs whose file changed on disk (Native)
+    #[cfg(not(target_arch = "wasm32"))]
+    fn reload_files_externally_changed(&mut self, ctx: &egui::Context) {
+        self.ensure_tabs();
+        let changed = {
+            let Some(watcher) = self.file_watcher.as_mut() else {
+                return;
+            };
+            watcher.changed_files(Instant::now())
+        };
+        if changed.is_empty() {
+            return;
+        }
+
+        // Collect target tabs first, then reload to avoid borrowing issues.
+        let mut targets = Vec::new();
+        for (idx, tab) in self.tabs.iter().enumerate() {
+            if tab.file_path.is_empty() {
+                continue;
+            }
+            let path = PathBuf::from(&tab.file_path);
+            let Ok(canonical) = path.canonicalize() else {
+                continue;
+            };
+            if changed.contains(&canonical) {
+                targets.push((idx, path));
+            }
+        }
+        for (idx, path) in targets {
+            self.load_file_into_tab(idx, path.clone(), ctx.clone());
+            self.register_file_watcher(&path);
+        }
     }
 
     /// Increment filter version to trigger recompute
@@ -1537,6 +1614,15 @@ impl FastCsvApp {
 
         let idx = self.active_tab_index;
 
+        // Stop watching the file being closed
+        #[cfg(not(target_arch = "wasm32"))]
+        {
+            let path = self.tabs[idx].file_path.clone();
+            if !path.is_empty() {
+                self.unregister_file_watcher(&path);
+            }
+        }
+
         // Adjust active tab index
         if idx > 0 {
             self.active_tab_index = idx - 1;
@@ -1633,6 +1719,14 @@ impl FastCsvApp {
         for idx in tabs_to_close {
             if self.tabs.len() <= 1 {
                 break;
+            }
+            // Stop watching the file being closed
+            #[cfg(not(target_arch = "wasm32"))]
+            {
+                let path = self.tabs[idx].file_path.clone();
+                if !path.is_empty() {
+                    self.unregister_file_watcher(&path);
+                }
             }
             if idx < self.active_tab_index {
                 self.active_tab_index -= 1;
@@ -4006,7 +4100,11 @@ impl eframe::App for FastCsvApp {
         }
 
         #[cfg(not(target_arch = "wasm32"))]
-        self.consume_pending_native_open_paths(ctx);
+        {
+            self.consume_pending_native_open_paths(ctx);
+            // Reload any open files that changed on disk
+            self.reload_files_externally_changed(ctx);
+        }
 
         // Check for updates on startup (only once)
         if !self.update_state.check_initiated {
@@ -4781,6 +4879,7 @@ fn main() -> eframe::Result<()> {
 
             // Load recent files from storage
             let mut app = FastCsvApp::default();
+            app.init_file_watcher(cc.egui_ctx.clone());
             app.load_recent_files();
             app.recent_files_loaded = true;
             app.consume_pending_native_open_paths(&cc.egui_ctx);
@@ -5096,6 +5195,64 @@ mod native_file_open_tests {
 
         let _ = std::fs::remove_file(first);
         let _ = std::fs::remove_file(second);
+    }
+
+    #[test]
+    fn external_file_change_triggers_tab_reload() {
+        use std::sync::atomic::Ordering;
+        use std::time::{Duration, Instant};
+
+        let file = temp_csv_path("reload.csv");
+        std::fs::write(&file, "name\nalice\n").expect("should create csv");
+
+        let mut app = FastCsvApp::default();
+        let ctx = egui::Context::default();
+        app.init_file_watcher(ctx.clone());
+        app.open_native_path(file.clone(), &ctx);
+
+        // Wait for the initial load to finish indexing (1 data row).
+        let initial_deadline = Instant::now() + Duration::from_secs(5);
+        loop {
+            let done = {
+                let state = app.tabs[0].state.read();
+                state.indexing_complete.load(Ordering::Relaxed)
+            };
+            if done {
+                break;
+            }
+            assert!(
+                Instant::now() < initial_deadline,
+                "initial load did not finish indexing in time"
+            );
+            std::thread::sleep(Duration::from_millis(20));
+        }
+
+        // Modify the file externally, then drive the update loop until the
+        // reload lands and the new rows are visible.
+        std::fs::write(&file, "name\nbob\ncarol\ndave\n").expect("should overwrite csv");
+
+        let reload_deadline = Instant::now() + Duration::from_secs(8);
+        loop {
+            app.reload_files_externally_changed(&ctx);
+            let rows = {
+                let state = app.tabs[0].state.read();
+                state
+                    .csv
+                    .as_ref()
+                    .map(|c| c.indexed_row_count())
+                    .unwrap_or(0)
+            };
+            if rows >= 3 {
+                break; // New content (3 data rows) has been picked up.
+            }
+            assert!(
+                Instant::now() < reload_deadline,
+                "external change was not picked up after reload; rows = {rows}"
+            );
+            std::thread::sleep(Duration::from_millis(50));
+        }
+
+        let _ = std::fs::remove_file(file);
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -2843,7 +2843,7 @@ impl FastCsvApp {
                     .fill(Color32::from_rgb(25, 25, 30))
                     .corner_radius(egui::CornerRadius::same(6))
                     .inner_margin(12.0)
-                    .stroke(egui::Stroke::new(1.0, Color32::from_rgb(50, 50, 60)))
+                    .stroke(egui::Stroke::new(1.0_f32, Color32::from_rgb(50, 50, 60)))
                     .show(ui, |ui| {
                         egui::ScrollArea::both()
                             .auto_shrink([false, false])
@@ -3612,7 +3612,7 @@ impl FastCsvApp {
             // Shortcut key badge on the right
             egui::Frame::NONE
                 .fill(Color32::from_rgb(35, 35, 40))
-                .stroke(egui::Stroke::new(1.0, Color32::from_rgb(55, 55, 60)))
+                .stroke(egui::Stroke::new(1.0_f32, Color32::from_rgb(55, 55, 60)))
                 .corner_radius(egui::CornerRadius::same(4))
                 .inner_margin(egui::Margin::symmetric(10, 5))
                 .show(ui, |ui| {


### PR DESCRIPTION
## Summary
Adds automatic reload of open CSV files when they are modified externally (e.g. edited by another program).

## How it works
- New `src/file_watcher.rs` module using the `notify` crate (FSEvents on macOS)
- Watches the **parent directory** of each open file, so atomic saves (rename-based editor saves) are detected
- Filters events to content changes (write/create/rename/remove); ignores pure metadata events (mtime/chmod)
- 500ms debounce collapses multi-event saves into one reload
- Reload targets the specific tab(s) by path; multiple tabs showing the same file all refresh
- Watchers are unregistered when tabs close; watcher lifecycle is desktop-only (WASM loads files into browser memory and cannot watch the filesystem)

## Testing
- `cargo fmt` / `cargo clippy -- -D warnings` clean
- 95 tests pass, including:
  - Unit tests for event-kind filtering (`is_content_change`)
  - End-to-end test: opens a real CSV, rewrites the file on disk, drives the update loop, asserts the new rows appear
- Manually verified on macOS: editing an open CSV externally updates the UI within ~1s

## Files changed
- `Cargo.toml` / `Cargo.lock`: add `notify = 8.2` (native-only dependency)
- `src/file_watcher.rs`: new watcher module
- `src/main.rs`: watcher integration, `load_file` refactor, tab-close unregistration

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Auto-reloads open CSV tabs when the file changes on disk. Previously, external edits were not reflected until a manual reopen; now desktop builds refresh affected tabs within ~1s without user action.

- New filesystem watcher (`src/file_watcher.rs`) uses `notify` to watch parent directories, filters to content changes, and debounces events for 500ms; paths are canonicalized so the correct tabs reload, including multiple tabs of the same file.
- App integration: initialize the watcher at startup, register on file open, unregister on tab close, and poll each frame to reload changed tabs via `load_file_into_tab`; reload resets tab scroll and state like a fresh open.
- Native-only; web builds are unchanged. Adds `notify` to native dependencies in `Cargo.toml`.
- Tests: unit tests for event filtering and a native end-to-end test that edits a real CSV and verifies reloaded rows appear.
- Clippy fixes: byte string literal for delimiter detection and explicit `f32` stroke literals.

<sup>Written for commit 68b46a55fddde0b89065a8315d770a502570aace. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ayu5h-raj/quickcsv/pull/38?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

